### PR TITLE
Fix issue 11

### DIFF
--- a/R/stem_generator.R
+++ b/R/stem_generator.R
@@ -34,13 +34,20 @@ stem_generator = function(poscolumn, max_combos = 3, all_diseases,
 
   # generate the base of the stem
   main_stem = sapply(poscolumn, function(x) {
+
+    if(x[[1]] == '-1'){
+      return(0)
+    }
     a = all_dis_count[x]
     # if only one disease, that is the base.
     if(length(a) == 1){
       return(x)}
     else{
       # else get the largest of those you select.
-      return(which(all_dis_count == max(a))[1])}
+      biggest = which(all_dis_count == max(a)) # if multiple, first find only those in x
+      largest = biggest[which(biggest %in% x)][[1]]
+      # if multiple, take the first
+      return(largest)}
   })
 
   # deal with 0000 later

--- a/tests/testthat/test_stem_generators.R
+++ b/tests/testthat/test_stem_generators.R
@@ -36,6 +36,8 @@ test_that('stems are an s3 class',{
 })
 
 test_that('ties are handled correctly',{
-  tied_data <- c('0001', '0011', '0010')
+  tied_data <- c('0001', '0011', '0010', '1000', '1000')
+  # in old version, this returned 1;3-4 for stem of row 3 which should be 3;3-4
   stem <- make_stem(tied_data)
+  expect_equal(stem[3,'stem'], '3;3-4')
 })

--- a/tests/testthat/test_stem_generators.R
+++ b/tests/testthat/test_stem_generators.R
@@ -35,3 +35,7 @@ test_that('stems are an s3 class',{
   expect_s3_class(make_stem(equal_strings), 'stem')
 })
 
+test_that('ties are handled correctly',{
+  tied_data <- c('0001', '0011', '0010')
+  stem <- make_stem(tied_data)
+})


### PR DESCRIPTION
This PR fixes issue #11 .

The problem was in `stem_generator`. `main_stem` was initialised on the basis of the commonest element. There was a tie between items 46 (n=966) and 9 (n=966) and so the first of these was taken.

This has been resolved by adding a check to only pull elements that are in the initial vector `poscolumn` vector that is passed to `sapply` :
`  main_stem = sapply(poscolumn, function(x) {

    if(x[[1]] == '-1'){
      return(0)
    }
    a = all_dis_count[x]
    # if only one disease, that is the base.
    if(length(a) == 1){
      return(x)}
    else{
      # else get the largest of those you select.
      biggest = which(all_dis_count == max(a)) # if multiple, first find only those in x
      largest = biggest[which(biggest %in% x)][[1]]
      # if multiple, take the first
      return(largest)}})`