### PR TITLE
Add cardinality

### DIFF
--- a/R/calculate_group_frequency.R
+++ b/R/calculate_group_frequency.R
@@ -6,7 +6,7 @@
 #' @param outcome_positions Numeric vector where each element refers to a record that suffered a particular outcome.
 #' @param min_freq Number between 0 and 1; minimum proportion of code combinations to be included in the stem. If \code{outcome_column} is passed, \code{min_freq} is the minimum event rate per combination to be considered.
 #' @param tots Numeric, total length of \code{comorbid_column} initially profiled to calculate frequency proportions to compare against \code{min_freq}.
-#'
+#' @param use_outcome Logical if to use outcome variable for stem generation.
 #' @return data.frame ordered from lowest to highest proportion of those suffering outcomes (if \code{outcome_positions} entered) or number of records associated with that combination (if no \code{outcome_positions} entered).
 #'
 #' @examples
@@ -24,7 +24,7 @@
 #' @export
 
 
-calculate_group_frequency <- function(unique_combinations, all_diseases, outcome_positions, min_freq=0, tots){
+calculate_group_frequency <- function(unique_combinations, all_diseases, outcome_positions, min_freq=0, tots, use_outcome = FALSE){
   # logic for parameter entry:
   # set up disease list
   setups = .get_list_pos(all_diseases)
@@ -45,7 +45,7 @@ calculate_group_frequency <- function(unique_combinations, all_diseases, outcome
 
   combos_outcome$propr_out = combos_outcome$out/combos_outcome$freq
 
-  if(length(outcome_positions) == 1){
+  if(length(outcome_positions) == 1 | use_outcome == FALSE){
     # if no outcomes data, then just do based on freq
     combos_outcome = combos_outcome[combos_outcome$freq/tots >= min_freq, ]
 

--- a/R/get_combinations.R
+++ b/R/get_combinations.R
@@ -39,3 +39,4 @@ get_combos = function(positions, combinations = 2){
     return(t(utils::combn(position_, combinations)))
   }
 }
+

--- a/R/make_stem.R
+++ b/R/make_stem.R
@@ -81,7 +81,7 @@ make_stem <- function(comorbid_column,
       intersect_w_count <- Reduce(intersect, dis_rows, count_rows) # intersection
       exclusive_intersect <- length(intersect_w_count)
       exclusive_outcome <- intersect(intersect_w_count, outcome_positions)
-      return(list('number_with_count' = length(count_rows), 'number_with_this' = exclusive_intersect, 'number_with_outcome' = .make_zero(exclusive_outcome)))
+      return(list('number_with_count' = length(count_rows), 'number_with_exlcusive_combo' = exclusive_intersect, 'number_with_outcome_this_combo' = .make_zero(exclusive_outcome)))
     })
 
     exclusive_format <- do.call(rbind, exclusive_results)

--- a/R/stem_generator.R
+++ b/R/stem_generator.R
@@ -6,6 +6,7 @@
 #' @param min_freq Number between 0 and 1; minimum proportion of code combinations to be included in the stem. If \code{outcome_column} is passed, \code{min_freq} is the minimum event rate per combination to be considered.
 #' @param outcome_positions Numeric vector where each number refers to a record that suffered a particular outcome.
 #' @param tots Total number of records included to allow calculation of disease frequency.
+#' @param use_outcome Logical if to use outcome variable for stem generation.
 #' @returns A dataframe with the \code{main_stem} for each pattern up to a maximum set in \code{max_combos}.
 #' @examples
 #' positions = list(c(1,2,3,4), c(3), c(3), c(2,3))
@@ -27,7 +28,8 @@
 #' @export
 
 stem_generator = function(poscolumn, max_combos = 3, all_diseases,
-                          outcome_positions = 0, min_freq = 0, tots){
+                          outcome_positions = 0, min_freq = 0, tots,
+                          use_outcome = FALSE){
   all_dis_count = sapply(all_diseases, length)
 
   # generate the base of the stem
@@ -65,7 +67,7 @@ stem_generator = function(poscolumn, max_combos = 3, all_diseases,
     }
     # if only one combination, update.
     else if(nrow(combos) == 1){
-      combo_freq = calculate_group_frequency(combos, all_diseases = all_diseases, outcome_positions = outcome_positions, min_freq=min_freq, tots = tots)
+      combo_freq = calculate_group_frequency(combos, all_diseases = all_diseases, outcome_positions = outcome_positions, min_freq=min_freq, tots = tots, use_outcome = use_outcome)
 
       rows_relevent = which(sapply(poscolumn, function(x) all(combos[1:i] %in% x)))
       if(nrow(combo_freq) == 0)
@@ -76,7 +78,7 @@ stem_generator = function(poscolumn, max_combos = 3, all_diseases,
     }
 
     else{
-      combo_freq = calculate_group_frequency(combos, all_diseases = all_diseases, outcome_positions = outcome_positions, min_freq=min_freq, tots = tots)
+      combo_freq = calculate_group_frequency(combos, all_diseases = all_diseases, outcome_positions = outcome_positions, min_freq=min_freq, tots = tots, use_outcome = use_outcome)
       # work through each row (this has been ordered ascending so last item should be most frequent)
       for(rows in 1:nrow(combo_freq)){
         # select relevant combos

--- a/README.MD
+++ b/README.MD
@@ -13,8 +13,8 @@ Degree = N overlaps
 
 Things to do:
  1. Clean up code to make more generalisable (?combineR)
- 2. Reduce redundency
- 3. Add tests for cardinality
+~~ 2. Reduce redundency ~~
+~~ 3. Add tests for cardinality ~~
  4. Consistent documentation
  5. Implement deviation. 
  6. ?implement upset visualisation

--- a/README.MD
+++ b/README.MD
@@ -13,6 +13,5 @@ Degree = N overlaps
 
 Things to do:
  1. Clean up code to make more generalisable
- 2. Separate out exclusive sets from aggregate sets
  3. Implement deviation. 
  4. ?implement upset visualisation

--- a/README.MD
+++ b/README.MD
@@ -12,6 +12,9 @@ Cardinality = N
 Degree = N overlaps
 
 Things to do:
- 1. Clean up code to make more generalisable
- 3. Implement deviation. 
- 4. ?implement upset visualisation
+ 1. Clean up code to make more generalisable (?combineR)
+ 2. Reduce redundency
+ 3. Add tests for cardinality
+ 4. Consistent documentation
+ 5. Implement deviation. 
+ 6. ?implement upset visualisation

--- a/man/calculate_group_frequency.Rd
+++ b/man/calculate_group_frequency.Rd
@@ -9,7 +9,8 @@ calculate_group_frequency(
   all_diseases,
   outcome_positions,
   min_freq = 0,
-  tots
+  tots,
+  use_outcome = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ calculate_group_frequency(
 \item{min_freq}{Number between 0 and 1; minimum proportion of code combinations to be included in the stem. If \code{outcome_column} is passed, \code{min_freq} is the minimum event rate per combination to be considered.}
 
 \item{tots}{Numeric, total length of \code{comorbid_column} initially profiled to calculate frequency proportions to compare against \code{min_freq}.}
+
+\item{use_outcome}{Logical if to use outcome variable for stem generation.}
 }
 \value{
 data.frame ordered from lowest to highest proportion of those suffering outcomes (if \code{outcome_positions} entered) or number of records associated with that combination (if no \code{outcome_positions} entered).

--- a/man/make_stem.Rd
+++ b/man/make_stem.Rd
@@ -8,7 +8,8 @@ make_stem(
   comorbid_column,
   max = "default",
   min_freq = 0,
-  outcome_column = NULL
+  outcome_column = NULL,
+  use_outcome = FALSE
 )
 }
 \arguments{
@@ -20,6 +21,8 @@ If data contains elements with multiple states (i.e. where a character element m
 \item{min_freq}{Number between 0 and 1; minimum proportion of code combinations to be included in the stem. If \code{outcome_column} is passed, \code{min_freq} is the minimum event rate per combination to be considered.}
 
 \item{outcome_column}{A numeric vector one if outcome occurred and zero if outcome did not occur. Should be the same length as \code{comorbid_column} with each element relating to the same record as the \code{comorbid_column}. If \code{outcome_column} is passed, then the stem will be generated based on combinations with the highest event rate.}
+
+\item{use_outcome}{Logical if to use outcome variable for stem generation.}
 }
 \value{
 data.frame with one row per unique \code{comorbid_string} pattern and columns: \code{comorbid_string} pattern, frequency of string pattern, positions within the pattern, stem and if frequency or outcome was used.

--- a/man/stem_generator.Rd
+++ b/man/stem_generator.Rd
@@ -10,7 +10,8 @@ stem_generator(
   all_diseases,
   outcome_positions = 0,
   min_freq = 0,
-  tots
+  tots,
+  use_outcome = FALSE
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ stem_generator(
 \item{min_freq}{Number between 0 and 1; minimum proportion of code combinations to be included in the stem. If \code{outcome_column} is passed, \code{min_freq} is the minimum event rate per combination to be considered.}
 
 \item{tots}{Total number of records included to allow calculation of disease frequency.}
+
+\item{use_outcome}{Logical if to use outcome variable for stem generation.}
 }
 \value{
 A dataframe with the \code{main_stem} for each pattern up to a maximum set in \code{max_combos}.

--- a/tests/testthat/test_group_frequency.R
+++ b/tests/testthat/test_group_frequency.R
@@ -17,7 +17,8 @@ outcomes = c(1,0,0,1)
 test_that('frequency or outcome correctly captured',{
   expect_equal(names(calculate_group_frequency(unique_combinations = unique_pos, all_diseases = disease_counts, outcome_positions = 0, tots = 4))[3:5], c('freq', 'outcome', 'propr_out'))
   expect_equal(calculate_group_frequency(unique_combinations = unique_pos, all_diseases = disease_counts, outcome_positions = 0, tots = 4)[4,1], 2)
-  expect_equal(calculate_group_frequency(unique_combinations = unique_pos, all_diseases = disease_counts, outcome_positions = outcomes, tots = 4)[1,'propr_out'], 0.5)
+  expect_equal(calculate_group_frequency(unique_combinations = unique_pos, all_diseases = disease_counts, outcome_positions = outcomes, tots = 4)[1,'propr_out'], 1.0) # no use_outcome flag; so uses frequency
+  expect_equal(calculate_group_frequency(unique_combinations = unique_pos, all_diseases = disease_counts, outcome_positions = outcomes, tots = 4, use_outcome = TRUE)[1,'propr_out'], 0.5) #use_outcome so uses outcome proportion
 })
 
 test_that('reduce overlap works', {

--- a/tests/testthat/test_stem_generators.R
+++ b/tests/testthat/test_stem_generators.R
@@ -21,7 +21,9 @@ test_that("error messages are captured in make_stem", {
 
 test_that("frequency or outcome are accurately reported", {
   expect_equal(make_stem(equal_strings, outcome_column =  NULL)[1,'freq_or_outcome'], 'frequency')
-  expect_equal(make_stem(equal_strings, outcome_column = outcomes)[1,'freq_or_outcome'], 'outcome')
+  expect_equal(make_stem(equal_strings, outcome_column = outcomes)[1,'freq_or_outcome'], 'frequency') # simply passing an outcome col not sufficient
+  expect_equal(make_stem(equal_strings, outcome_column = outcomes, use_outcome = TRUE)[1,'freq_or_outcome'], 'outcome') # simply passing an outcome col not sufficient
+
 })
 
 test_that('make stem works accurately', {
@@ -44,7 +46,9 @@ test_that('ties are handled correctly',{
 
 test_that('outcome_capture_correct', {
   cc_string <- c('1001', '0100', '1101', '1001') # by frequency stem for 3 should be 1;1-4
-  outcome_string <- c('0', '1', '1', '0') # by outcome should be 1;2-4
+  outcome_string <- c('0', '1', '1', '0') # by outcome should be 1;2-4 IF use_outcome is provided
   expect_equal(make_stem(cc_string, max=2)[3,4], "1;1-4")
-  expect_equal(make_stem(cc_string, outcome_column = outcome_string, max=2)[3,4], "1;2-4")
+  expect_equal(make_stem(cc_string, outcome_column = outcome_string, max=2)[3,4], "1;1-4")
+  expect_equal(make_stem(cc_string, outcome_column = outcome_string, max=2, use_outcome = TRUE)[3,4], "1;2-4")
+  expect_equal(make_stem(cc_string, outcome_column=outcome_string, max=2, use_outcome=FALSE)[1:2,6],c(1,0))
 })


### PR DESCRIPTION
Add outcome measures at a pattern level (i.e. outcome per row of the eventual stem outputs).
This is particularly useful because it allows assessment at cardinality level.

Important change is the addition of the `use_outcome` flag to ensure control of stem generation.